### PR TITLE
Implement model loading via STL/OBJ

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,16 @@
 </head>
 <body>
     <div id="viewer"></div>
-    <div id="panel"></div>
-    <script type="module" src="../src/viewer.js"></script>
+    <div id="panel">
+        <input type="file" id="file-input" accept=".stl,.obj">
+        <div id="drop-zone">Drop STL/OBJ here</div>
+    </div>
+    <script type="module">
+        import { init as initViewer } from '../src/viewer.js';
+        import { init as initFile } from '../src/fileManager.js';
+
+        initViewer('viewer');
+        initFile('file-input', 'drop-zone');
+    </script>
 </body>
 </html>

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -1,5 +1,74 @@
+import { loadMesh } from './viewer.js';
+import { STLLoader } from 'https://unpkg.com/three@0.152.2/examples/jsm/loaders/STLLoader.js';
+import { OBJLoader } from 'https://unpkg.com/three@0.152.2/examples/jsm/loaders/OBJLoader.js';
+
 export async function loadFile(path) {
-    // Placeholder for file loading logic
     console.log(`Loading file: ${path}`);
-    // return file data/model
 }
+
+export function init(inputId, dropZoneId) {
+    const input = document.getElementById(inputId);
+    const dropZone = document.getElementById(dropZoneId);
+
+    if (input) {
+        input.addEventListener('change', (event) => {
+            const file = event.target.files[0];
+            if (file) {
+                handleFile(file);
+                input.value = '';
+            }
+        });
+    }
+
+    if (dropZone) {
+        ['dragover', 'dragenter'].forEach(type => {
+            dropZone.addEventListener(type, (e) => {
+                e.preventDefault();
+            });
+        });
+
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            const file = e.dataTransfer.files[0];
+            if (file) {
+                handleFile(file);
+            }
+        });
+    }
+}
+
+export function handleFile(file) {
+    const extension = file.name.split('.').pop().toLowerCase();
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+        let geometry;
+        if (extension === 'stl') {
+            const loader = new STLLoader();
+            geometry = loader.parse(event.target.result);
+        } else if (extension === 'obj') {
+            const loader = new OBJLoader();
+            const object = loader.parse(event.target.result);
+            const mesh = object.children.find((child) => child.isMesh);
+            if (mesh) {
+                geometry = mesh.geometry;
+            }
+        }
+
+        if (geometry) {
+            loadMesh(geometry);
+        } else {
+            console.error('Unsupported file format:', extension);
+        }
+    };
+
+    if (extension === 'stl') {
+        reader.readAsArrayBuffer(file);
+    } else if (extension === 'obj') {
+        reader.readAsText(file);
+    } else {
+        console.error('Unsupported file format:', extension);
+    }
+}
+
+export { handleFile };

--- a/src/style.css
+++ b/src/style.css
@@ -12,3 +12,10 @@
     background-color: #ffffff;
     border-left: 1px solid #ddd;
 }
+
+#drop-zone {
+    border: 2px dashed #ccc;
+    padding: 20px;
+    margin: 10px;
+    text-align: center;
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,4 +1,3 @@
-import { loadFile } from './fileManager.js';
 import { calculateCost } from './calculator.js';
 import config from './config.json' assert { type: 'json' };
 import * as THREE from 'https://unpkg.com/three@0.152.2/build/three.module.js';
@@ -7,11 +6,6 @@ import { OrbitControls } from 'https://unpkg.com/three@0.152.2/examples/jsm/cont
 console.log('Viewer initialized');
 console.log('Current material prices:', config.prices);
 
-// Example usage
-// loadFile('path/to/model.stl').then(model => {
-//     const cost = calculateCost(model);
-//     console.log('Model cost', cost);
-// });
 
 let scene, camera, renderer, controls, mesh;
 


### PR DESCRIPTION
## Summary
- add `init` and `handleFile` to manage file uploads
- hook file input & drop zone in the example page
- style drop zone panel
- clean up unused code in viewer

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6851857dba788333a2299fccfd9bb179