### PR TITLE
Implement calcPrice and formatting

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,5 +1,34 @@
-export function calculateCost(model) {
-    // Placeholder for cost calculation
-    console.log('Calculating cost for model');
-    return 0;
+let config;
+
+export async function initConfig() {
+    const response = await fetch('./config.json');
+    if (!response.ok) {
+        throw new Error('Failed to load config.json');
+    }
+    config = await response.json();
+    return config;
+}
+
+export function calcPrice({ volume_cm3, material }) {
+    if (!config) {
+        throw new Error('Config not initialized');
+    }
+
+    const materialCfg = config.materials[material];
+    if (!materialCfg) {
+        throw new Error(`Unknown material: ${material}`);
+    }
+
+    const { density, priceKg } = materialCfg;
+    const { laborRate } = config;
+    const infill = 0.2;
+    const mass = volume_cm3 * density * infill;
+    const materialCost = mass * (priceKg / 1000);
+    const timeHrs = volume_cm3 * infill / 10;
+    const labor = timeHrs * laborRate;
+    return Math.round((materialCost + labor) * 1.2);
+}
+
+export function formatPrice(rub) {
+    return `${rub} ₽`;
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
-    "prices": {
-        "PLA": 20,
-        "ABS": 25
-    }
+  "materials": {
+    "PLA": {"density": 1.24, "priceKg": 1500},
+    "ABS": {"density": 1.04, "priceKg": 1700}
+  },
+  "laborRate": 200
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,10 +1,11 @@
-import { calculateCost } from './calculator.js';
-import config from './config.json' assert { type: 'json' };
+import { initConfig } from './calculator.js';
 import * as THREE from 'https://unpkg.com/three@0.152.2/build/three.module.js';
 import { OrbitControls } from 'https://unpkg.com/three@0.152.2/examples/jsm/controls/OrbitControls.js';
 
 console.log('Viewer initialized');
-console.log('Current material prices:', config.prices);
+initConfig().then(cfg => {
+    console.log('Current material prices:', cfg.materials);
+});
 
 
 let scene, camera, renderer, controls, mesh;


### PR DESCRIPTION
## Summary
- add material data to `config.json`
- implement `initConfig`, `calcPrice`, and `formatPrice`
- load configuration in `viewer.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851868b38a88333b03a30261ab5cf55