### PR TITLE
Add logo and legal placeholders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,12 @@
     <link rel="stylesheet" href="../src/style.css">
 </head>
 <body>
-    <div id="viewer"></div>
-    <div id="panel">
+    <header>
+        <img id="logo" src="../assets/logo.svg" alt="Step3D Logo">
+    </header>
+    <main id="main">
+        <div id="viewer"></div>
+        <div id="panel">
         <input type="file" id="fileInput" accept=".stl,.obj">
         <div id="drop-zone">Drop STL/OBJ here</div>
         <select id="material">
@@ -20,6 +24,11 @@
         <p id="volume"></p>
         <p id="price"></p>
     </div>
+    </main>
+    <footer>
+        <a href="privacy.html">Политика конфиденциальности</a> |
+        <a href="offer.html">Публичная оферта</a>
+    </footer>
     <script type="module">
         import { init as initViewer } from '../src/viewer.js';
         import { init as initFile } from '../src/fileManager.js';

--- a/public/offer.html
+++ b/public/offer.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Публичная оферта</title>
+    <link rel="stylesheet" href="../src/style.css">
+</head>
+<body>
+    <header>
+        <a href="index.html">&larr; На главную</a>
+    </header>
+    <main id="main">
+        <p>Здесь будет размещен текст публичной оферты.</p>
+    </main>
+    <footer>
+        <a href="privacy.html">Политика конфиденциальности</a> |
+        <a href="offer.html">Публичная оферта</a>
+    </footer>
+</body>
+</html>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Политика конфиденциальности</title>
+    <link rel="stylesheet" href="../src/style.css">
+</head>
+<body>
+    <header>
+        <a href="index.html">&larr; На главную</a>
+    </header>
+    <main id="main">
+        <p>Здесь будет размещена политика конфиденциальности.</p>
+    </main>
+    <footer>
+        <a href="privacy.html">Политика конфиденциальности</a> |
+        <a href="offer.html">Публичная оферта</a>
+    </footer>
+</body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -2,7 +2,13 @@ body {
     font-family: Inter, Arial, sans-serif;
     margin: 0;
     display: flex;
-    height: 100vh;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#main {
+    flex: 1;
+    display: flex;
 }
 
 #viewer {
@@ -33,4 +39,21 @@ select {
 #error {
     color: red;
     margin-top: 12px;
+}
+
+header {
+    padding: 16px;
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+#logo {
+    height: 40px;
+}
+
+footer {
+    text-align: center;
+    padding: 10px;
+    font-size: 14px;
+    background: #f9f9f9;
 }


### PR DESCRIPTION
## Summary
- add header and footer layout
- show site logo from `assets/logo.svg`
- link to placeholder pages for privacy policy and public offer
- create placeholder files `privacy.html` and `offer.html`
- update styles for header, footer and layout

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68519021f238833396e7fb75c9c70b18