### PR TITLE
Add viewer MVP controls

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,9 @@
             <option value="ABS">ABS</option>
         </select>
         <input type="number" id="scaleFactor" value="1" min="0.1" step="0.1" placeholder="Scale">
+        <input type="color" id="colorPicker" value="#cccccc">
+        <label><input type="checkbox" id="wireframe"> Wireframe</label>
+        <button id="resetView">Reset view</button>
         <p id="error" style="display:none"></p>
         <p id="volume"></p>
         <p id="price"></p>
@@ -35,12 +38,28 @@
         <a href="offer.html">Публичная оферта</a>
     </footer>
     <script type="module">
-        import { init as initViewer } from '../src/viewer.js';
+        import {
+            init as initViewer,
+            resetView,
+            setMeshColor,
+            setWireframe
+        } from '../src/viewer.js';
         import { init as initFile } from '../src/fileManager.js';
 
         /* Запускаем инициализацию просмотра и обработку файлов */
         initViewer('viewer');
         initFile('fileInput', 'drop-zone');
+
+        // обработчики дополнительных элементов управления
+        document.getElementById('colorPicker').addEventListener('input', (e) => {
+            setMeshColor(e.target.value);
+        });
+        document.getElementById('wireframe').addEventListener('change', (e) => {
+            setWireframe(e.target.checked);
+        });
+        document.getElementById('resetView').addEventListener('click', () => {
+            resetView();
+        });
     </script>
 </body>
 </html>

--- a/src/style.css
+++ b/src/style.css
@@ -31,6 +31,18 @@ select {
     padding: 8px;
 }
 
+input[type="color"] {
+    padding: 0;
+    height: 40px;
+}
+
+button {
+    width: 100%;
+    margin-top: 12px;
+    padding: 8px;
+    cursor: pointer;
+}
+
 #drop-zone {
     border: 2px dashed #ccc;
     padding: 20px;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -12,6 +12,7 @@ initConfig().then(cfg => {
 
 // Глобальные переменные сцены Three.js
 let scene, camera, renderer, controls, mesh;
+let gridHelper, axesHelper;
 
 /**
  * Создаёт сцену Three.js внутри элемента с указанным id.
@@ -39,6 +40,12 @@ export function init(canvasId) {
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight);
     container.appendChild(renderer.domElement);
+
+    // вспомогательная сетка и оси для ориентира
+    gridHelper = new THREE.GridHelper(200, 50);
+    axesHelper = new THREE.AxesHelper(100);
+    scene.add(gridHelper);
+    scene.add(axesHelper);
 
     const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
     dirLight.position.set(5, 10, 7.5);
@@ -112,4 +119,47 @@ function fitCameraToGeometry(geometry) {
     camera.updateProjectionMatrix();
 }
 
-export { THREE };
+// Сброс камеры на исходное положение относительно модели
+export function resetView() {
+    if (mesh) {
+        fitCameraToGeometry(mesh.geometry);
+        controls.target.set(0, 0, 0);
+        controls.update();
+    }
+}
+
+// Изменяет цвет материала модели
+export function setMeshColor(hex) {
+    if (mesh && mesh.material) {
+        mesh.material.color.set(hex);
+    }
+}
+
+// Переключает режим отображения каркаса
+export function setWireframe(enabled) {
+    if (mesh && mesh.material) {
+        mesh.material.wireframe = enabled;
+    }
+}
+
+// Показывает или скрывает сетку и оси
+export function showHelpers(show) {
+    if (!scene) return;
+    if (show) {
+        if (gridHelper && axesHelper) {
+            scene.add(gridHelper);
+            scene.add(axesHelper);
+        }
+    } else {
+        if (gridHelper) scene.remove(gridHelper);
+        if (axesHelper) scene.remove(axesHelper);
+    }
+}
+
+export {
+    THREE,
+    resetView,
+    setMeshColor,
+    setWireframe,
+    showHelpers
+};


### PR DESCRIPTION
## Summary
- extend viewer to control camera, color and wireframe
- wire new controls up in demo page
- style new controls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `npm run dev` *(starts http-server)*

------
https://chatgpt.com/codex/tasks/task_e_6851b58877c88333bb9c7687a413cbbc