### PR TITLE
Add URL loading and OpenAI style tweaks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,8 @@
         <!-- Выбор файла и настройка печати -->
         <input type="file" id="fileInput" accept=".stl,.obj">
         <div id="drop-zone">Drop STL/OBJ here</div>
+        <input type="url" id="urlInput" placeholder="Model URL">
+        <button id="loadUrl">Load from URL</button>
         <select id="material">
             <option value="PLA">PLA</option>
             <option value="ABS">ABS</option>
@@ -26,6 +28,7 @@
         <input type="number" id="scaleFactor" value="1" min="0.1" step="0.1" placeholder="Scale">
         <input type="color" id="colorPicker" value="#cccccc">
         <label><input type="checkbox" id="wireframe"> Wireframe</label>
+        <label><input type="checkbox" id="helpers" checked> Helpers</label>
         <button id="resetView">Reset view</button>
         <p id="error" style="display:none"></p>
         <p id="volume"></p>
@@ -42,9 +45,10 @@
             init as initViewer,
             resetView,
             setMeshColor,
-            setWireframe
+            setWireframe,
+            showHelpers
         } from '../src/viewer.js';
-        import { init as initFile } from '../src/fileManager.js';
+        import { init as initFile, loadFile } from '../src/fileManager.js';
 
         /* Запускаем инициализацию просмотра и обработку файлов */
         initViewer('viewer');
@@ -57,8 +61,15 @@
         document.getElementById('wireframe').addEventListener('change', (e) => {
             setWireframe(e.target.checked);
         });
+        document.getElementById('helpers').addEventListener('change', (e) => {
+            showHelpers(e.target.checked);
+        });
         document.getElementById('resetView').addEventListener('click', () => {
             resetView();
+        });
+        document.getElementById('loadUrl').addEventListener('click', () => {
+            const url = document.getElementById('urlInput').value.trim();
+            if (url) loadFile(url);
         });
     </script>
 </body>

--- a/offer.html
+++ b/offer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Публичная оферта</title>
     <!-- Общие стили сайта -->
-    <link rel="stylesheet" href="../src/style.css">
+    <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
     <header>

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Политика конфиденциальности</title>
     <!-- Подключаем общие стили -->
-    <link rel="stylesheet" href="../src/style.css">
+    <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
     <header>

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -14,7 +14,21 @@ const configReady = initConfig();
 
 // Загружает файл по ссылке (не используется напрямую)
 export async function loadFile(path) {
-    console.log(`Loading file: ${path}`);
+    clearError();
+    try {
+        const res = await fetch(path);
+        if (!res.ok) {
+            showError('Не удалось загрузить файл');
+            return;
+        }
+        const blob = await res.blob();
+        const name = path.split('/').pop() || 'model';
+        const file = new File([blob], name);
+        await handleFile(file);
+    } catch (err) {
+        console.error('Failed to load remote file', err);
+        showError('Ошибка загрузки файла');
+    }
 }
 
 /**

--- a/src/style.css
+++ b/src/style.css
@@ -5,6 +5,8 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    background: #f7f7f8;
+    color: #202123;
 }
 
 #main {
@@ -15,12 +17,14 @@ body {
 #viewer {
     flex: 3;
     background: #fff;
+    border-right: 1px solid #e0e0e0;
 }
 
 #panel {
     flex: 1;
     padding: 24px;
     box-shadow: -1px 0 4px rgba(0, 0, 0, .05);
+    background: #fff;
 }
 
 /* Поля ввода и списки материалов */
@@ -29,6 +33,8 @@ select {
     width: 100%;
     margin-top: 12px;
     padding: 8px;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
 }
 
 input[type="color"] {
@@ -41,6 +47,14 @@ button {
     margin-top: 12px;
     padding: 8px;
     cursor: pointer;
+    background: #10a37f;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+}
+
+button:hover {
+    background: #0d8b68;
 }
 
 #drop-zone {
@@ -48,11 +62,14 @@ button {
     padding: 20px;
     margin: 10px;
     text-align: center;
+    border-radius: 4px;
+    color: #666;
 }
 
 #error {
     color: red;
     margin-top: 12px;
+    font-weight: bold;
 }
 
 /* Простой стиль для шапки и подвала */
@@ -60,6 +77,7 @@ header {
     padding: 16px;
     background: #fff;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+    border-bottom: 1px solid #e0e0e0;
 }
 
 #logo {
@@ -71,4 +89,5 @@ footer {
     padding: 10px;
     font-size: 14px;
     background: #f9f9f9;
+    border-top: 1px solid #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- add UI elements for loading model via URL and toggling helpers
- implement `loadFile` to fetch remote models
- tweak styles to look more like OpenAI
- fix paths in legal pages

## Testing
- `npm run dev` *(fails: http-server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c16b6a608333881d2cd0016bd3da