### PR TITLE
Add upload button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
         <!-- Выбор файла и настройка печати -->
         <label class="theme-switch"><input type="checkbox" id="themeToggle"> Dark mode</label>
         <input type="file" id="fileInput" accept=".stl,.obj">
+        <button id="uploadBtn">Загрузить 3D-модель</button>
         <p id="fileName"></p>
         <div id="drop-zone">Прикрепите 3D-модель</div>
         <input type="url" id="urlInput" placeholder="Model URL">
@@ -62,6 +63,9 @@
         /* Запускаем инициализацию просмотра и обработку файлов */
         initViewer('viewer');
         initFile('fileInput', 'drop-zone');
+        document.getElementById('uploadBtn').addEventListener('click', () => {
+            document.getElementById('fileInput').click();
+        });
 
         const panel = document.getElementById('panel');
         const toggleBtn = document.getElementById('togglePanel');

--- a/src/style.css
+++ b/src/style.css
@@ -156,6 +156,10 @@ footer {
     word-break: break-all;
 }
 
+#fileInput {
+    display: none;
+}
+
 #togglePanel {
     width: auto;
     margin-left: auto;


### PR DESCRIPTION
## Summary
- add button to upload 3D model
- hide the default file input
- trigger file selection via the new button

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run dev` *(starts http server but no public directory)*

------
https://chatgpt.com/codex/tasks/task_e_685286aeb9248333a420046af8238ba3